### PR TITLE
Add support for Literal types

### DIFF
--- a/typeddict_validator/validate.py
+++ b/typeddict_validator/validate.py
@@ -1,5 +1,6 @@
 from typing import (
     Any,
+    Literal,
     Type,
     TypeGuard,
     TypeVar,
@@ -75,6 +76,9 @@ def _validate_value(k: str, v: Any, expected: Any):
             _raise_if_mismatch(k=k, v=v_, expected=expected, actual=v)
     elif is_typeddict(expected):
         validate_typeddict(v, expected)
+    elif origin_type_expected is Literal:
+        if v not in get_args(expected):
+            raise DictValueTypeMismatchException(key=k, expected=expected, actual=v)
     elif type(v) != expected:
         raise_()
 

--- a/typeddict_validator/validate_test.py
+++ b/typeddict_validator/validate_test.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Type, TypedDict, Union
+from typing import Any, Literal, Optional, Type, TypedDict, Union
 import unittest
 
 from .validate import (
@@ -26,6 +26,10 @@ class HasDictValueTypedDict(TypedDict):
     d_union: dict[str, Union[str, int]]
     d_optional: dict[str, Optional[str]]
     d_any: dict[str, Any]
+
+
+class HasLiteralValueTypedDict(TypedDict):
+    l: Literal["Hello", "World"]
 
 
 class HasTypedDictValueTypedDict(TypedDict):
@@ -95,6 +99,14 @@ class TestValidateTypedDict(unittest.TestCase):
         (
             {"u": 0, "o": None, "o_list": None, "o_dict": None},
             HasUnionValueTypedDict,
+        ),
+        (
+            {"l": "Hello"},
+            HasLiteralValueTypedDict,
+        ),
+        (
+            {"l": "World"},
+            HasLiteralValueTypedDict,
         ),
     ]
 
@@ -244,6 +256,27 @@ class TestValidateTypedDict(unittest.TestCase):
                     "o_dict": {"s": 0},  # o_dict is invalid
                 },
                 HasUnionValueTypedDict,
+            ),
+            DictValueTypeMismatchException,
+        ),
+        (
+            (
+                {"l": "asdf"},
+                HasLiteralValueTypedDict,
+            ),
+            DictValueTypeMismatchException,
+        ),
+        (
+            (
+                {"l": "hello"},
+                HasLiteralValueTypedDict,
+            ),
+            DictValueTypeMismatchException,
+        ),
+        (
+            (
+                {"l": 5},
+                HasLiteralValueTypedDict,
             ),
             DictValueTypeMismatchException,
         ),


### PR DESCRIPTION
Adds support for `Literal` types. (with tests)


## Example
```py
from typing import Literal, TypedDict

class MyType(TypedDict):
    name = Literal["John", "Jane"]
```
